### PR TITLE
Change target release process

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,8 @@
 name: Publish
 
 on:
-  push:
-    branches:
-      - main
+  release:
+    types: [released]
 
 jobs:
   publish:


### PR DESCRIPTION
### 🎯 Goal

Change target release process to [released].

For now, GitHub workflow runs a `release` process for every commit against the main branch. 