### PR TITLE
Inject Context into PushDelegate

### DIFF
--- a/stream-android-push-delegate/api/stream-android-push-delegate.api
+++ b/stream-android-push-delegate/api/stream-android-push-delegate.api
@@ -5,7 +5,9 @@ public final class io/getstream/android/push/delegate/BuildConfig {
 	public fun <init> ()V
 }
 
-public abstract interface class io/getstream/android/push/delegate/PushDelegate {
+public abstract class io/getstream/android/push/delegate/PushDelegate {
+	public fun <init> (Landroid/content/Context;)V
+	public final fun getContext ()Landroid/content/Context;
 	public abstract fun handlePushMessage (Ljava/util/Map;)Z
 	public abstract fun registerPushDevice (Lio/getstream/android/push/PushDevice;)V
 }

--- a/stream-android-push-delegate/src/main/java/io/getstream/android/push/delegate/PushDelegate.kt
+++ b/stream-android-push-delegate/src/main/java/io/getstream/android/push/delegate/PushDelegate.kt
@@ -15,9 +15,10 @@
  */
 
 package io.getstream.android.push.delegate
+import android.content.Context
 import io.getstream.android.push.PushDevice
 
-public interface PushDelegate {
+public abstract class PushDelegate(public val context: Context) {
 
     /**
      * Handles push message payload.
@@ -27,12 +28,12 @@ public interface PushDelegate {
      * @param payload The payload to be handled.
      * @return True if the payload was handled.
      */
-    public fun handlePushMessage(payload: Map<String, Any?>): Boolean
+    public abstract fun handlePushMessage(payload: Map<String, Any?>): Boolean
 
     /**
      * Register a new [PushDevice]
      *
      * @param pushDevice The PushDevice to be registered.
      */
-    public fun registerPushDevice(pushDevice: PushDevice)
+    public abstract fun registerPushDevice(pushDevice: PushDevice)
 }


### PR DESCRIPTION
### 🎯 Goal
Inject `Context` into `PushDelegate` to be able to use Android Stuff from the custom implementation of `PushDelegate`.
`PushDelegate` needed to be converted into an abstract class instead of an interface.
### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF
![](https://media.giphy.com/media/4Kz0smpvpGT3ZcdVMA/giphy.gif)