### PR TITLE
Ensure the last resumed activity is the one used to request push notification permissions

### DIFF
--- a/stream-android-push-permissions/src/main/java/io/getstream/android/push/permissions/PushNotificationPermissionRequester.kt
+++ b/stream-android-push-permissions/src/main/java/io/getstream/android/push/permissions/PushNotificationPermissionRequester.kt
@@ -63,6 +63,12 @@ internal class PushNotificationPermissionRequester private constructor() : Activ
         super.onActivityStarted(activity)
     }
 
+    override fun onActivityResumed(activity: Activity) {
+        logger.v { "[onActivityResumed] activity: $activity" }
+        currentActivity = activity
+        super.onActivityResumed(activity)
+    }
+
     override fun onActivityStopped(activity: Activity) {
         logger.v { "[onActivityStopped] activity: $activity" }
         activity.unregisterPermissionCallback()


### PR DESCRIPTION

### 🎯 Goal
Ensure the last resumed activity is the one used to request push notification permissions.
It prevents the SDK crashes on case a floating activity is started over the activity that requests the Push Notification Permission, like the case of a log-in with the Google Play Services

### 🎉 GIF

![](https://media.giphy.com/media/JPgVtxHIl4lMcnAlWB/giphy.gif)