### PR TITLE
Add proguard rule for push delegate classes

### DIFF
--- a/.github/actions/gradle-cache/action.yml
+++ b/.github/actions/gradle-cache/action.yml
@@ -7,7 +7,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/cache@v3.0.11
+    - uses: actions/cache@v4
       with:
         path: |
           ~/.gradle/caches

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Unit tests
         run: ./gradlew test
       - name: Upload testDebugUnitTest results
-        uses: actions/upload-artifact@v3.1.0
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: testDebugUnitTest

--- a/stream-android-push-delegate/consumer-rules.pro
+++ b/stream-android-push-delegate/consumer-rules.pro
@@ -1,2 +1,2 @@
 # Classes that are used by reflection.
--keep class io.getstream.android.push.delegate.PushDelegateProvider { *; }
+-keep class io.getstream.android.push.delegate.** { *; }


### PR DESCRIPTION
### 🎯 Goal

Prevent runtime errors due to the missing push delegate classes

Fix #27 

### 🛠 Implementation details

- Add proguard rule for push delegate classes
- Update some Github actions that were breaking CI

### 🎉 GIF

![gif](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExNjg0dGExMTUxMHY2cWdveWZsdmc0a3d0d2wyNjJvamtiODN4cnVxMCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/l4JyX3V0yydvPHNBe/giphy.gif)
