### PR TITLE
Add Pre-hook Interceptors for Push Notification Events

### DIFF
--- a/stream-android-push-firebase/src/androidMain/kotlin/io/getstream/android/push/firebase/ChatFirebaseMessagingService.kt
+++ b/stream-android-push-firebase/src/androidMain/kotlin/io/getstream/android/push/firebase/ChatFirebaseMessagingService.kt
@@ -17,14 +17,23 @@ package io.getstream.android.push.firebase
 
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
+import io.getstream.android.push.PushProvider
+import io.getstream.android.push.interceptor.PushEventInterceptor
 import io.getstream.log.StreamLog
 
 internal class ChatFirebaseMessagingService : FirebaseMessagingService() {
   private val logger = StreamLog.getLogger("Push:Firebase")
+  private var interceptor: PushEventInterceptor? = null
 
   override fun onMessageReceived(remoteMessage: RemoteMessage) {
     logger.d { "[onFirebaseMessageReceived] remoteMessage: $remoteMessage" }
     try {
+      if (interceptor != null) {
+        if (interceptor?.preOnRemoteMessage(PushProvider.FIREBASE) == false) {
+          return
+        }
+      }
+
       FirebaseMessagingDelegate.handleRemoteMessage(remoteMessage)
         .also {
           when (it) {
@@ -41,6 +50,11 @@ internal class ChatFirebaseMessagingService : FirebaseMessagingService() {
 
   override fun onNewToken(token: String) {
     try {
+      if (interceptor != null) {
+        if (interceptor?.preOnNewToken(PushProvider.FIREBASE) == false) {
+          return
+        }
+      }
       FirebaseMessagingDelegate.registerFirebaseToken(token, "")
     } catch (exception: IllegalStateException) {
       logger.e(exception) { "[onFirebaseNewToken] error while registering Firebase Token" }

--- a/stream-android-push-firebase/src/androidMain/kotlin/io/getstream/android/push/firebase/ChatFirebaseMessagingService.kt
+++ b/stream-android-push-firebase/src/androidMain/kotlin/io/getstream/android/push/firebase/ChatFirebaseMessagingService.kt
@@ -18,18 +18,17 @@ package io.getstream.android.push.firebase
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import io.getstream.android.push.PushProvider
-import io.getstream.android.push.interceptor.PushEventInterceptor
+import io.getstream.android.push.interceptor.StreamPushInterceptor
 import io.getstream.log.StreamLog
 
 internal class ChatFirebaseMessagingService : FirebaseMessagingService() {
   private val logger = StreamLog.getLogger("Push:Firebase")
-  private var interceptor: PushEventInterceptor? = null
 
   override fun onMessageReceived(remoteMessage: RemoteMessage) {
     logger.d { "[onFirebaseMessageReceived] remoteMessage: $remoteMessage" }
     try {
-      if (interceptor != null) {
-        if (interceptor?.preOnRemoteMessage(PushProvider.FIREBASE) == false) {
+      if (StreamPushInterceptor.interceptor != null) {
+        if (StreamPushInterceptor.interceptor?.preOnRemoteMessage(PushProvider.FIREBASE) == false) {
           return
         }
       }
@@ -50,11 +49,12 @@ internal class ChatFirebaseMessagingService : FirebaseMessagingService() {
 
   override fun onNewToken(token: String) {
     try {
-      if (interceptor != null) {
-        if (interceptor?.preOnNewToken(PushProvider.FIREBASE) == false) {
+      if (StreamPushInterceptor.interceptor != null) {
+        if (StreamPushInterceptor.interceptor?.preOnNewToken(PushProvider.FIREBASE) == false) {
           return
         }
       }
+
       FirebaseMessagingDelegate.registerFirebaseToken(token, "")
     } catch (exception: IllegalStateException) {
       logger.e(exception) { "[onFirebaseNewToken] error while registering Firebase Token" }

--- a/stream-android-push-huawei/src/androidMain/kotlin/io/getstream/android/push/huawei/ChatHuaweiMessagingService.kt
+++ b/stream-android-push-huawei/src/androidMain/kotlin/io/getstream/android/push/huawei/ChatHuaweiMessagingService.kt
@@ -17,14 +17,22 @@ package io.getstream.android.push.huawei
 
 import com.huawei.hms.push.HmsMessageService
 import com.huawei.hms.push.RemoteMessage
+import io.getstream.android.push.PushProvider
+import io.getstream.android.push.interceptor.PushEventInterceptor
 import io.getstream.log.StreamLog
 
 internal class ChatHuaweiMessagingService : HmsMessageService() {
   private val logger = StreamLog.getLogger("Push:Huawei")
+  private var interceptor: PushEventInterceptor? = null
 
   override fun onMessageReceived(remoteMessage: RemoteMessage) {
     logger.d { "[onHuaweiMessageReceived] remoteMessage: $remoteMessage" }
     try {
+      if (interceptor != null) {
+        if (interceptor?.preOnRemoteMessage(PushProvider.HUAWEI) == false) {
+          return
+        }
+      }
       HuaweiMessagingDelegate.handleRemoteMessage(remoteMessage)
         .also {
           when (it) {
@@ -41,6 +49,11 @@ internal class ChatHuaweiMessagingService : HmsMessageService() {
 
   override fun onNewToken(token: String) {
     try {
+      if (interceptor != null) {
+        if (interceptor?.preOnNewToken(PushProvider.HUAWEI) == false) {
+          return
+        }
+      }
       HuaweiMessagingDelegate.registerHuaweiToken(token, "")
     } catch (exception: IllegalStateException) {
       logger.e(exception) { "[onHuaweiNewToken] error while registering Huawei Token" }

--- a/stream-android-push-huawei/src/androidMain/kotlin/io/getstream/android/push/huawei/ChatHuaweiMessagingService.kt
+++ b/stream-android-push-huawei/src/androidMain/kotlin/io/getstream/android/push/huawei/ChatHuaweiMessagingService.kt
@@ -19,6 +19,7 @@ import com.huawei.hms.push.HmsMessageService
 import com.huawei.hms.push.RemoteMessage
 import io.getstream.android.push.PushProvider
 import io.getstream.android.push.interceptor.PushEventInterceptor
+import io.getstream.android.push.interceptor.StreamPushInterceptor
 import io.getstream.log.StreamLog
 
 internal class ChatHuaweiMessagingService : HmsMessageService() {
@@ -28,8 +29,8 @@ internal class ChatHuaweiMessagingService : HmsMessageService() {
   override fun onMessageReceived(remoteMessage: RemoteMessage) {
     logger.d { "[onHuaweiMessageReceived] remoteMessage: $remoteMessage" }
     try {
-      if (interceptor != null) {
-        if (interceptor?.preOnRemoteMessage(PushProvider.HUAWEI) == false) {
+      if (StreamPushInterceptor.interceptor != null) {
+        if (StreamPushInterceptor.interceptor?.preOnRemoteMessage(PushProvider.HUAWEI) == false) {
           return
         }
       }
@@ -49,11 +50,12 @@ internal class ChatHuaweiMessagingService : HmsMessageService() {
 
   override fun onNewToken(token: String) {
     try {
-      if (interceptor != null) {
-        if (interceptor?.preOnNewToken(PushProvider.HUAWEI) == false) {
+      if (StreamPushInterceptor.interceptor != null) {
+        if (StreamPushInterceptor.interceptor?.preOnNewToken(PushProvider.HUAWEI) == false) {
           return
         }
       }
+
       HuaweiMessagingDelegate.registerHuaweiToken(token, "")
     } catch (exception: IllegalStateException) {
       logger.e(exception) { "[onHuaweiNewToken] error while registering Huawei Token" }

--- a/stream-android-push-xiaomi/src/androidMain/kotlin/io/getstream/android/push/xiaomi/ChatXiaomiMessagingReceiver.kt
+++ b/stream-android-push-xiaomi/src/androidMain/kotlin/io/getstream/android/push/xiaomi/ChatXiaomiMessagingReceiver.kt
@@ -21,6 +21,7 @@ import com.xiaomi.mipush.sdk.MiPushMessage
 import com.xiaomi.mipush.sdk.PushMessageReceiver
 import io.getstream.android.push.PushProvider
 import io.getstream.android.push.interceptor.PushEventInterceptor
+import io.getstream.android.push.interceptor.StreamPushInterceptor
 import io.getstream.log.StreamLog
 
 /**
@@ -42,11 +43,12 @@ public class ChatXiaomiMessagingReceiver : PushMessageReceiver() {
   ) {
     logger.i { "[onReceiveXiaomiPassThroughMessage] miPushMessage: $miPushMessage" }
     try {
-      if (interceptor != null) {
-        if (interceptor?.preOnRemoteMessage(PushProvider.XIAOMI) == false) {
+      if (StreamPushInterceptor.interceptor != null) {
+        if (StreamPushInterceptor.interceptor?.preOnRemoteMessage(PushProvider.XIAOMI) == false) {
           return
         }
       }
+
       XiaomiMessagingDelegate.handleMiPushMessage(miPushMessage)
         .also {
           when (it) {
@@ -71,11 +73,12 @@ public class ChatXiaomiMessagingReceiver : PushMessageReceiver() {
   ) {
     logger.d { "[onReceiveXiaomiRegisterResult] miPushCommandMessage: $miPushCommandMessage" }
     try {
-      if (interceptor != null) {
-        if (interceptor?.preOnNewToken(PushProvider.XIAOMI) == false) {
+      if (StreamPushInterceptor.interceptor != null) {
+        if (StreamPushInterceptor.interceptor?.preOnNewToken(PushProvider.XIAOMI) == false) {
           return
         }
       }
+
       XiaomiMessagingDelegate.registerXiaomiToken(miPushCommandMessage, "")
     } catch (exception: IllegalStateException) {
       logger.e(exception) { "[onReceiveRegisterResult] error while registering Xiaomi Token" }

--- a/stream-android-push-xiaomi/src/androidMain/kotlin/io/getstream/android/push/xiaomi/ChatXiaomiMessagingReceiver.kt
+++ b/stream-android-push-xiaomi/src/androidMain/kotlin/io/getstream/android/push/xiaomi/ChatXiaomiMessagingReceiver.kt
@@ -19,6 +19,8 @@ import android.content.Context
 import com.xiaomi.mipush.sdk.MiPushCommandMessage
 import com.xiaomi.mipush.sdk.MiPushMessage
 import com.xiaomi.mipush.sdk.PushMessageReceiver
+import io.getstream.android.push.PushProvider
+import io.getstream.android.push.interceptor.PushEventInterceptor
 import io.getstream.log.StreamLog
 
 /**
@@ -26,6 +28,7 @@ import io.getstream.log.StreamLog
  */
 public class ChatXiaomiMessagingReceiver : PushMessageReceiver() {
   private val logger = StreamLog.getLogger("Push:Xiaomi")
+  private var interceptor: PushEventInterceptor? = null
 
   /**
    * This method is called when a push notification is received from Xiaomi Servers.
@@ -39,6 +42,11 @@ public class ChatXiaomiMessagingReceiver : PushMessageReceiver() {
   ) {
     logger.i { "[onReceiveXiaomiPassThroughMessage] miPushMessage: $miPushMessage" }
     try {
+      if (interceptor != null) {
+        if (interceptor?.preOnRemoteMessage(PushProvider.XIAOMI) == false) {
+          return
+        }
+      }
       XiaomiMessagingDelegate.handleMiPushMessage(miPushMessage)
         .also {
           when (it) {
@@ -63,6 +71,11 @@ public class ChatXiaomiMessagingReceiver : PushMessageReceiver() {
   ) {
     logger.d { "[onReceiveXiaomiRegisterResult] miPushCommandMessage: $miPushCommandMessage" }
     try {
+      if (interceptor != null) {
+        if (interceptor?.preOnNewToken(PushProvider.XIAOMI) == false) {
+          return
+        }
+      }
       XiaomiMessagingDelegate.registerXiaomiToken(miPushCommandMessage, "")
     } catch (exception: IllegalStateException) {
       logger.e(exception) { "[onReceiveRegisterResult] error while registering Xiaomi Token" }

--- a/stream-android-push/api/android/stream-android-push.api
+++ b/stream-android-push/api/android/stream-android-push.api
@@ -42,7 +42,7 @@ public abstract interface class io/getstream/android/push/interceptor/PushEventI
 
 public final class io/getstream/android/push/interceptor/StreamPushInterceptor {
 	public static final field INSTANCE Lio/getstream/android/push/interceptor/StreamPushInterceptor;
-	public final fun getPushInterceptor ()Lio/getstream/android/push/interceptor/PushEventInterceptor;
-	public final fun setPushInterceptor (Lio/getstream/android/push/interceptor/PushEventInterceptor;)V
+	public final fun getInterceptor ()Lio/getstream/android/push/interceptor/PushEventInterceptor;
+	public final fun setInterceptor (Lio/getstream/android/push/interceptor/PushEventInterceptor;)V
 }
 

--- a/stream-android-push/api/android/stream-android-push.api
+++ b/stream-android-push/api/android/stream-android-push.api
@@ -35,3 +35,14 @@ public final class io/getstream/android/push/PushProvider$Companion {
 	public final fun fromKey (Ljava/lang/String;)Lio/getstream/android/push/PushProvider;
 }
 
+public abstract interface class io/getstream/android/push/interceptor/PushEventInterceptor {
+	public abstract fun preOnNewToken (Lio/getstream/android/push/PushProvider;)Z
+	public abstract fun preOnRemoteMessage (Lio/getstream/android/push/PushProvider;)Z
+}
+
+public final class io/getstream/android/push/interceptor/StreamPushInterceptor {
+	public static final field INSTANCE Lio/getstream/android/push/interceptor/StreamPushInterceptor;
+	public final fun getPushInterceptor ()Lio/getstream/android/push/interceptor/PushEventInterceptor;
+	public final fun setPushInterceptor (Lio/getstream/android/push/interceptor/PushEventInterceptor;)V
+}
+

--- a/stream-android-push/api/jvm/stream-android-push.api
+++ b/stream-android-push/api/jvm/stream-android-push.api
@@ -42,7 +42,7 @@ public abstract interface class io/getstream/android/push/interceptor/PushEventI
 
 public final class io/getstream/android/push/interceptor/StreamPushInterceptor {
 	public static final field INSTANCE Lio/getstream/android/push/interceptor/StreamPushInterceptor;
-	public final fun getPushInterceptor ()Lio/getstream/android/push/interceptor/PushEventInterceptor;
-	public final fun setPushInterceptor (Lio/getstream/android/push/interceptor/PushEventInterceptor;)V
+	public final fun getInterceptor ()Lio/getstream/android/push/interceptor/PushEventInterceptor;
+	public final fun setInterceptor (Lio/getstream/android/push/interceptor/PushEventInterceptor;)V
 }
 

--- a/stream-android-push/api/jvm/stream-android-push.api
+++ b/stream-android-push/api/jvm/stream-android-push.api
@@ -35,3 +35,14 @@ public final class io/getstream/android/push/PushProvider$Companion {
 	public final fun fromKey (Ljava/lang/String;)Lio/getstream/android/push/PushProvider;
 }
 
+public abstract interface class io/getstream/android/push/interceptor/PushEventInterceptor {
+	public abstract fun preOnNewToken (Lio/getstream/android/push/PushProvider;)Z
+	public abstract fun preOnRemoteMessage (Lio/getstream/android/push/PushProvider;)Z
+}
+
+public final class io/getstream/android/push/interceptor/StreamPushInterceptor {
+	public static final field INSTANCE Lio/getstream/android/push/interceptor/StreamPushInterceptor;
+	public final fun getPushInterceptor ()Lio/getstream/android/push/interceptor/PushEventInterceptor;
+	public final fun setPushInterceptor (Lio/getstream/android/push/interceptor/PushEventInterceptor;)V
+}
+

--- a/stream-android-push/src/commonMain/kotlin/io/getstream/android/push/interceptor/PushEventInterceptor.kt
+++ b/stream-android-push/src/commonMain/kotlin/io/getstream/android/push/interceptor/PushEventInterceptor.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-android-push/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getstream.android.push.interceptor
+
+import io.getstream.android.push.PushProvider
+
+public interface PushEventInterceptor {
+  /**
+   * Called just before Push SDK forwards the new FCM/Xiaomi/Huawei token
+   * to the Video SDK.
+   *
+   * Return true to proceed, false to block.
+   */
+  public fun preOnNewToken(source: PushProvider): Boolean
+
+  /**
+   * Called just before Push SDK forwards a remote message
+   * to the Video SDK.
+   *
+   * Return true to proceed, false to block.
+   */
+  public fun preOnRemoteMessage(pushProvider: PushProvider): Boolean
+}

--- a/stream-android-push/src/commonMain/kotlin/io/getstream/android/push/interceptor/StreamPushInterceptor.kt
+++ b/stream-android-push/src/commonMain/kotlin/io/getstream/android/push/interceptor/StreamPushInterceptor.kt
@@ -16,5 +16,5 @@
 package io.getstream.android.push.interceptor
 
 public object StreamPushInterceptor {
-  public var pushInterceptor: PushEventInterceptor? = null
+  public var interceptor: PushEventInterceptor? = null
 }

--- a/stream-android-push/src/commonMain/kotlin/io/getstream/android/push/interceptor/StreamPushInterceptor.kt
+++ b/stream-android-push/src/commonMain/kotlin/io/getstream/android/push/interceptor/StreamPushInterceptor.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-android-push/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getstream.android.push.interceptor
+
+public object StreamPushInterceptor {
+  public var pushInterceptor: PushEventInterceptor? = null
+}


### PR DESCRIPTION
### 🎯 Goal

Add Pre-hook Interceptors for Push Notification Events which will allow integrators to re-initialise sdk before the code goes into PN

### Current Pain Points

- **Dropped Push Events** – Push messages were being dropped if the Video SDK was not ready, which forced clients to write their own PushService. This becomes a serious issue since FCM is not available on some Chinese OEMs (e.g., Xiaomi, Huawei), making custom implementations unreliable or impossible.

- **Token Refresh Handling** – Refresh token registration faced the same issue. Tokens could be dropped before Video SDK initialization, leaving no way to recover unless the client implemented their own PushService.

### Summary

This PR introduces pre-hook interceptors for Push SDK events (`onNewToken` and `onRemoteMessage`). These interceptors allow integrators to decide whether push events should be forwarded to the Video SDK, giving them finer control during initialization or app state transitions. 

These changes prevent silent failures when Video SDK is not ready and remove the need for clients to re-implement push handling


#### Changes

* Added `PushEventInterceptor` interface with:

  * `preOnNewToken(source: PushSource): Boolean`
  * `preOnRemoteMessage(source: PushSource): Boolean`
* Updated Push SDK handlers (FCM, Huawei, Xiaomi) to respect interceptor decisions before forwarding events.
* Default behavior (when no interceptor is set) remains unchanged → events are always forwarded.

### Example Usage

```kotlin
StreamPushInterceptor.pushInterceptor = object : PushEventInterceptor {
    override fun preOnNewToken(token: String, source: PushSource): Boolean {
        return VideoSdk.init()
    }

    override fun preOnRemoteMessage(message: RemoteMessage, source: PushSource): Boolean {
        return VideoSdk.init()
    }
}
```


