### PR TITLE
fix(delegate): lazy-init logger to prevent ANR during startup

### DIFF
--- a/stream-android-push-delegate/src/androidMain/kotlin/io/getstream/android/push/delegate/AndroidPushDelegateProvider.kt
+++ b/stream-android-push-delegate/src/androidMain/kotlin/io/getstream/android/push/delegate/AndroidPushDelegateProvider.kt
@@ -26,12 +26,11 @@ import android.os.Bundle
 import io.getstream.android.push.delegate.PushDelegateProvider.Companion.METADATA_VALUE
 import io.getstream.android.push.delegate.PushDelegateProvider.Companion._delegates
 import io.getstream.android.push.delegate.PushDelegateProvider.Companion.isInitialized
-import io.getstream.log.StreamLog
-import io.getstream.log.TaggedLogger
+import io.getstream.log.taggedLogger
 
 public class AndroidPushDelegateProvider : PushDelegateProvider, ContentProvider() {
 
-  private val logger: TaggedLogger = StreamLog.getLogger("Push:Delegate")
+  private val logger by taggedLogger("Push:Delegate")
 
   override fun onCreate(): Boolean {
     initializeDelegates()


### PR DESCRIPTION
## Summary

- Change eager `StreamLog.getLogger()` call in `AndroidPushDelegateProvider` to lazy `taggedLogger()` delegate
- `AndroidPushDelegateProvider` is a `ContentProvider` — its constructor runs on the main thread during `installContentProviders`, before `Application.onCreate()`
- The eager call triggered the full `StreamLog` → `ErrorStreamLogger` → `KotlinStreamLogger` → `kotlinx-datetime` class-loading chain on the main thread, causing ANRs on slower devices

## What changed

```diff
- private val logger: TaggedLogger = StreamLog.getLogger("Push:Delegate")
+ private val logger by taggedLogger("Push:Delegate")
```

Logger is now initialized on first use (in `toPushDelegate()` error/debug logs) instead of during ContentProvider construction.